### PR TITLE
Fix import error for energy unit

### DIFF
--- a/custom_components/genetic-load-manager/config_flow.py
+++ b/custom_components/genetic-load-manager/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
     CONF_NAME,
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
-    ENERGY_KILO_WATT_HOUR,
+    UnitOfEnergy,
     PERCENTAGE,
     CURRENCY_EURO,
     CURRENCY_DOLLAR
@@ -105,7 +105,7 @@ CONFIG_SCHEMA = vol.Schema({
     vol.Required("load_sensor_entity", description="Select Energy Consumption Sensor for Historical Data"): create_entity_selector(
         domain="sensor",
         device_class="energy",
-        unit=ENERGY_KILO_WATT_HOUR
+        unit=UnitOfEnergy.KILO_WATT_HOUR
     ),
     
     # Battery Management

--- a/custom_components/genetic-load-manager/sensor.py
+++ b/custom_components/genetic-load-manager/sensor.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
-from homeassistant.const import ENERGY_KILO_WATT_HOUR
+from homeassistant.const import UnitOfEnergy
 from homeassistant.helpers.event import async_track_time_interval
 from datetime import datetime, timedelta
 import numpy as np
@@ -46,7 +46,7 @@ class LoadForecastSensor(SensorEntity):
         self.hass = hass
         self._attr_unique_id = f"{DOMAIN}_load_forecast"
         self._attr_name = "Load Forecast"
-        self._attr_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        self._attr_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         self._attr_device_class = "energy"
         self._load_sensor_entity = config.get("load_sensor_entity")
         self._forecast = []


### PR DESCRIPTION
Update `ENERGY_KILO_WATT_HOUR` to `UnitOfEnergy.KILO_WATT_HOUR` to fix import errors in newer Home Assistant versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-9446330d-60aa-49d3-aa08-31aecd4c48dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9446330d-60aa-49d3-aa08-31aecd4c48dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

