### PR TITLE
Resolve numpy dependency conflict

### DIFF
--- a/custom_components/genetic_load_manager/manifest.json
+++ b/custom_components/genetic_load_manager/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "genetic_load_manager",
   "name": "Genetic Load Manager",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "documentation": "https://github.com/filipe0doria/genetic-load-manager",
   "issue_tracker": "https://github.com/filipe0doria/genetic-load-manager/issues",
   "dependencies": ["sensor", "binary_sensor", "switch", "recorder"],
-  "requirements": ["numpy>=1.21.0,<2.0.0"],
+  "requirements": ["numpy>=1.21.0"],
   "codeowners": ["@filipe0doria"],
   "iot_class": "local_polling",
   "config_flow": true,


### PR DESCRIPTION
Update `genetic_load_manager` manifest to support numpy 2.x and resolve dependency conflicts.

The previous `requirements` constraint `"numpy>=1.21.0,<2.0.0"` prevented Home Assistant from installing numpy 2.x, leading to a "Config flow could not be loaded" error. This change removes the upper version limit, allowing numpy 2.x to be installed, and the component's code has been verified for numpy 2.x compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-1caeed96-6bb8-4ce9-95b9-76d1e61c2f3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1caeed96-6bb8-4ce9-95b9-76d1e61c2f3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

